### PR TITLE
Fixed fail report by adding missing prereq Mojo::File.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -49,3 +49,4 @@ repository.type = git
 [Prereqs]
 perl = 5.010
 Mojolicious = 5.67
+Mojo::File = 0


### PR DESCRIPTION
Hi @reneeb 

Please review the PR.
https://www.cpantesters.org/cpan/report/6d928bcc-530f-11e9-b233-b0531f24ea8f

                PERL_DL_NONLAZY=1 "/opt/perl-5.24.0/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" 
                "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t t/fields/*.t 
                t/validation/*.t
                Can't locate Mojo/File.pm in @INC (you may need to install the Mojo::File module) (@INC 
                contains: /home/cpansand/.cpan/build/2019033018/Mojolicious-Plugin-FormFieldsFromJSON- 
                1.01-2/blib/lib /home/cpansand/.cpan/build/2019033018/Mojolicious-Plugin- 
                FormFieldsFromJSON-1.01-2/blib/arch /opt/perl-5.24.0/lib/site_perl/5.24.0/x86_64-linux 
                /opt/perl-5.24.0/lib/site_perl/5.24.0 /opt/perl-5.24.0/lib/5.24.0/x86_64-linux /opt/perl- 
                5.24.0/lib/5.24.0 .) at /home/cpansand/.cpan/build/2019033018/Mojolicious-Plugin- 
                FormFieldsFromJSON-1.01-2/blib/lib/Mojolicious/Plugin/FormFieldsFromJSON.pm line 17.
                BEGIN failed--compilation aborted at /home/cpansand/.cpan/build/2019033018/Mojolicious- 
                Plugin-FormFieldsFromJSON-1.01-2/blib/lib/Mojolicious/Plugin/FormFieldsFromJSON.pm line 17.
                Compilation failed in require at (eval 89) line 1.
                t/02_two_fields.t ...................................... 
                Dubious, test returned 255 (wstat 65280, 0xff00)

Many Thanks.
Best Regards,
Mohammad S Anwar