### PR TITLE
Fix internal pod links.

### DIFF
--- a/lib/Mojolicious/Plugin/FormFieldsFromJSON.pm
+++ b/lib/Mojolicious/Plugin/FormFieldsFromJSON.pm
@@ -947,7 +947,7 @@ You get
 =item * translate_labels
 
 If I<translate_labels> is true, the labels for the templates are translated. You have to provide a
-I<translation_method|Mojolicious::Plugin::FormFieldsFromJSON/Translation_method>, too.
+L<translation_method|Mojolicious::Plugin::FormFieldsFromJSON/Translation_method>, too.
 
   plugin 'FormFieldsFromJSON' => {
     template           => '<%= $label %>: <%= $field %>',
@@ -955,12 +955,12 @@ I<translation_method|Mojolicious::Plugin::FormFieldsFromJSON/Translation_method>
     translation_method => \&loc,
   };
 
-For more details see I<Translation|Mojolicious::Plugin::FormFieldsFromJSON/Translation>.
+For more details see L<Translation|Mojolicious::Plugin::FormFieldsFromJSON/Translation>.
 
 =item * translation_method
 
 If I<translate_labels> is true, the labels for the templates are translated. You have to provide a
-I<translation_method|Mojolicious::Plugin::FormFieldsFromJSON/Translation_method>, too.
+L<translation_method|Mojolicious::Plugin::FormFieldsFromJSON/Translation_method>, too.
 
   plugin 'FormFieldsFromJSON' => {
     template           => '<%= $label %>: <%= $field %>',


### PR DESCRIPTION
Hello! This is from [pullrequest.club](https://pullrequest.club/). I have to admit I am not familiar with the `Mojolicious` framework (except from reading the documentation now) but I will take this as a challenge :) The framework looks very elegant from what I can see and the documentation is well written and concise.

Now, for this plugin module (it looks comprehensive and useful) I started reading the POD documentation and found a problem:

There are some internal references to the `Translate` section. These use the syntax `I<>`, whereas I think it was meant to use `L<>` to create a link?

Please let me know if there is anything else you would like me to work on.
Have a nice day!
